### PR TITLE
ci: build container images for all active Fedora releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+tmt/build.fmf linguist-generated
+.github/workflows/container.yml linguist-generated

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Schedule build via Testing Farm
         env:
           TESTING_FARM_API_TOKEN: ${{ secrets.TESTING_FARM_API_TOKEN }}
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           REPO_OWNER: ${{ github.repository_owner }}
           GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           TARGET_IMAGE: ghcr.io/thrix/nix-toolbox:${{ steps.tag.outputs.value }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -25,6 +25,8 @@ jobs:
             plan: /tmt/build/f42
           - version: "43"
             plan: /tmt/build/f43
+          - version: "44"
+            plan: /tmt/build/f44
           - version: rawhide
             plan: /tmt/build/rawhide
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,60 @@
+---
+name: Container Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+
+    strategy:
+      matrix:
+        include:
+          - version: "42"
+            plan: /tmt/build/f42
+          - version: "43"
+            plan: /tmt/build/f43
+          - version: rawhide
+            plan: /tmt/build/rawhide
+
+    container:
+      image: quay.io/testing-farm/cli:latest
+
+    steps:
+      - name: Compute image tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "value=pr-${{ github.event.number }}-${{ matrix.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "value=${{ matrix.version }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Schedule build via Testing Farm
+        env:
+          TESTING_FARM_API_TOKEN: ${{ secrets.TESTING_FARM_API_TOKEN }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          TARGET_IMAGE: ghcr.io/thrix/nix-toolbox:${{ steps.tag.outputs.value }}
+        run: |
+          AUTH_JSON_BASE64=$(echo "{\"auths\":{\"ghcr.io\":{\"auth\":\"$(echo -n "${REPO_OWNER}:${GHCR_TOKEN}" | base64 -w0)\"}}}" | base64 -w0)
+          testing-farm request \
+            -e ENABLE_PUSH="yes" \
+            -e GIT_REF="${GIT_SHA}" \
+            -e TARGET_IMAGE="${TARGET_IMAGE}" \
+            -s AUTH_JSON_BASE64="${AUTH_JSON_BASE64}" \
+            --plan "${{ matrix.plan }}" \
+            --git-url https://github.com/thrix/nix-toolbox \
+            --git-ref "${GIT_SHA}"

--- a/.github/workflows/container.yml.j2
+++ b/.github/workflows/container.yml.j2
@@ -44,7 +44,7 @@ jobs:
       - name: Schedule build via Testing Farm
         env:
           TESTING_FARM_API_TOKEN: ${{ secrets.TESTING_FARM_API_TOKEN }}
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           REPO_OWNER: ${{ github.repository_owner }}
           GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           TARGET_IMAGE: ghcr.io/thrix/nix-toolbox:${{ steps.tag.outputs.value }}

--- a/.github/workflows/container.yml.j2
+++ b/.github/workflows/container.yml.j2
@@ -21,13 +21,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - version: "42"
-            plan: /tmt/build/f42
-          - version: "43"
-            plan: /tmt/build/f43
+        {% for version in versions %}
+          - version: "{{ version }}"
+            plan: /tmt/build/f{{ version }}
+        {% endfor %}
           - version: rawhide
             plan: /tmt/build/rawhide
-
+{% raw %}
     container:
       image: quay.io/testing-farm/cli:latest
 
@@ -58,3 +58,4 @@ jobs:
             --plan "${{ matrix.plan }}" \
             --git-url https://github.com/thrix/nix-toolbox \
             --git-ref "${GIT_SHA}"
+{% endraw %}

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -14,7 +14,6 @@ jobs:
 
     permissions:
       contents: write
-      issues: write
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/refresh-build-fmf.yml
+++ b/.github/workflows/refresh-build-fmf.yml
@@ -29,20 +29,20 @@ jobs:
       - name: Install make
         run: sudo apt-get update && sudo apt-get install -y make
 
-      - name: Regenerate tmt/build.fmf
+      - name: Regenerate build configs
         run: make generate/build-fmf
 
       - name: Create pull request if changed
         uses: peter-evans/create-pull-request@v7
         with:
           commit-message: |
-            tmt: regenerate build.fmf for current Fedora releases
+            ci: regenerate build configs for current Fedora releases
 
             Assisted-by: Claude Code
           branch: refresh-build-fmf
-          title: 'tmt: regenerate build.fmf for current Fedora releases'
+          title: 'ci: regenerate build configs for current Fedora releases'
           body: |
-            Automated weekly refresh of `tmt/build.fmf` based on active Fedora releases from the Bodhi API.
+            Automated weekly refresh of `tmt/build.fmf` and `container.yml` based on active Fedora releases.
 
             Generated-by: Claude Code
           delete-branch: true

--- a/.github/workflows/refresh-build-fmf.yml
+++ b/.github/workflows/refresh-build-fmf.yml
@@ -1,0 +1,48 @@
+---
+name: Refresh build.fmf
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        run: python -m pip install --upgrade uv
+
+      - name: Install make
+        run: sudo apt-get update && sudo apt-get install -y make
+
+      - name: Regenerate tmt/build.fmf
+        run: make generate/build-fmf
+
+      - name: Create pull request if changed
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: |
+            tmt: regenerate build.fmf for current Fedora releases
+
+            Assisted-by: Claude Code
+          branch: refresh-build-fmf
+          title: 'tmt: regenerate build.fmf for current Fedora releases'
+          body: |
+            Automated weekly refresh of `tmt/build.fmf` based on active Fedora releases from the Bodhi API.
+
+            Generated-by: Claude Code
+          delete-branch: true

--- a/.github/workflows/refresh-build-fmf.yml
+++ b/.github/workflows/refresh-build-fmf.yml
@@ -37,12 +37,8 @@ jobs:
         with:
           commit-message: |
             ci: regenerate build configs for current Fedora releases
-
-            Assisted-by: Claude Code
           branch: refresh-build-fmf
           title: 'ci: regenerate build configs for current Fedora releases'
           body: |
             Automated weekly refresh of `tmt/build.fmf` and `container.yml` based on active Fedora releases.
-
-            Generated-by: Claude Code
           delete-branch: true

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 ROOT_DIR = $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 # Fedora toolbox version
-FEDORA_VERSION=42
+FEDORA_VERSION=43
 
 # Help prelude
 define PRELUDE
@@ -33,6 +33,11 @@ docs: .FORCE  ## Build documentation locally
 
 docs/serve: .FORCE  ## Run documentation development server
 	uv run mkdocs serve
+
+##@ Generate
+
+generate/build-fmf: .FORCE  ## Regenerate tmt/build.fmf from current Fedora active releases
+	uv run python scripts/generate-build-fmf.py
 
 ##@ Container
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ description = "Nix Toolbox Documentation"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+    "jinja2>=3.1",
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.6.14",
+    "requests>=2.32",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,5 @@ dependencies = [
     "jinja2>=3.1",
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.6.14",
-    "requests>=2.32",
+    "fedora-distro-aliases>=1.0",
 ]

--- a/scripts/generate-build-fmf.py
+++ b/scripts/generate-build-fmf.py
@@ -23,7 +23,7 @@ def get_active_fedora_versions() -> list[int]:
         sys.exit(1)
 
     versions = []
-    for distro in aliases.get("fedora-stable", []):
+    for distro in aliases.get("fedora-branched", []):
         version = distro.get("version_number")
         if version and version.isdigit():
             versions.append(int(version))

--- a/scripts/generate-build-fmf.py
+++ b/scripts/generate-build-fmf.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Generate tmt/build.fmf and update the container.yml matrix from active Fedora releases."""
+
+import re
+import sys
+from pathlib import Path
+
+import jinja2
+import requests
+
+BODHI_URL = "https://bodhi.fedoraproject.org/releases?rows_per_page=100&state=current"
+REPO_ROOT = Path(__file__).parent.parent
+TEMPLATE_PATH = REPO_ROOT / "tmt" / "build.fmf.j2"
+BUILD_FMF_PATH = REPO_ROOT / "tmt" / "build.fmf"
+CONTAINER_YML_PATH = REPO_ROOT / ".github" / "workflows" / "container.yml"
+
+# Markers for the matrix block in container.yml
+MATRIX_START = "        include:\n"
+MATRIX_END = "\n    container:\n"
+
+
+def get_active_fedora_versions() -> list[int]:
+    response = requests.get(BODHI_URL, timeout=30)
+    response.raise_for_status()
+    releases = response.json().get("releases", [])
+
+    versions = []
+    for release in releases:
+        name = release.get("name", "")
+        match = re.fullmatch(r"F(\d+)", name)
+        if match:
+            versions.append(int(match.group(1)))
+
+    return sorted(versions)
+
+
+def render_matrix_include(versions: list[int]) -> str:
+    lines = ["        include:\n"]
+    for version in versions:
+        lines.append(f'          - version: "{version}"\n')
+        lines.append(f"            plan: /tmt/build/f{version}\n")
+    lines.append('          - version: rawhide\n')
+    lines.append('            plan: /tmt/build/rawhide\n')
+    return "".join(lines)
+
+
+def update_container_yml(versions: list[int]) -> None:
+    text = CONTAINER_YML_PATH.read_text()
+    start_idx = text.index(MATRIX_START)
+    end_idx = text.index(MATRIX_END, start_idx)
+    new_matrix = render_matrix_include(versions)
+    text = text[:start_idx] + new_matrix + text[end_idx:]
+    CONTAINER_YML_PATH.write_text(text)
+    print(f"Updated matrix: {CONTAINER_YML_PATH}")
+
+
+def main() -> None:
+    versions = get_active_fedora_versions()
+    if not versions:
+        print("ERROR: No active Fedora releases found from Bodhi API.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Active Fedora releases: {versions}")
+
+    template_text = TEMPLATE_PATH.read_text()
+    template = jinja2.Template(template_text, keep_trailing_newline=True, trim_blocks=True, lstrip_blocks=True)
+    output = template.render(versions=versions)
+    BUILD_FMF_PATH.write_text(output)
+    print(f"Written: {BUILD_FMF_PATH}")
+
+    update_container_yml(versions)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-build-fmf.py
+++ b/scripts/generate-build-fmf.py
@@ -1,74 +1,55 @@
 #!/usr/bin/env python3
-"""Generate tmt/build.fmf and update the container.yml matrix from active Fedora releases."""
+"""Generate tmt/build.fmf and container.yml from active Fedora releases."""
 
-import re
 import sys
 from pathlib import Path
 
 import jinja2
-import requests
+from fedora_distro_aliases import get_distro_aliases
 
-BODHI_URL = "https://bodhi.fedoraproject.org/releases?rows_per_page=100&state=current"
 REPO_ROOT = Path(__file__).parent.parent
-TEMPLATE_PATH = REPO_ROOT / "tmt" / "build.fmf.j2"
-BUILD_FMF_PATH = REPO_ROOT / "tmt" / "build.fmf"
-CONTAINER_YML_PATH = REPO_ROOT / ".github" / "workflows" / "container.yml"
 
-# Markers for the matrix block in container.yml
-MATRIX_START = "        include:\n"
-MATRIX_END = "\n    container:\n"
+TEMPLATES = {
+    REPO_ROOT / "tmt" / "build.fmf.j2": REPO_ROOT / "tmt" / "build.fmf",
+    REPO_ROOT / ".github" / "workflows" / "container.yml.j2": REPO_ROOT / ".github" / "workflows" / "container.yml",
+}
 
 
 def get_active_fedora_versions() -> list[int]:
-    response = requests.get(BODHI_URL, timeout=30)
-    response.raise_for_status()
-    releases = response.json().get("releases", [])
+    try:
+        aliases = get_distro_aliases()
+    except (OSError, ValueError) as exc:
+        print(f"Failed to query active Fedora releases: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     versions = []
-    for release in releases:
-        name = release.get("name", "")
-        match = re.fullmatch(r"F(\d+)", name)
-        if match:
-            versions.append(int(match.group(1)))
+    for distro in aliases.get("fedora-stable", []):
+        version = distro.get("version_number")
+        if version and version.isdigit():
+            versions.append(int(version))
 
     return sorted(versions)
 
 
-def render_matrix_include(versions: list[int]) -> str:
-    lines = ["        include:\n"]
-    for version in versions:
-        lines.append(f'          - version: "{version}"\n')
-        lines.append(f"            plan: /tmt/build/f{version}\n")
-    lines.append('          - version: rawhide\n')
-    lines.append('            plan: /tmt/build/rawhide\n')
-    return "".join(lines)
-
-
-def update_container_yml(versions: list[int]) -> None:
-    text = CONTAINER_YML_PATH.read_text()
-    start_idx = text.index(MATRIX_START)
-    end_idx = text.index(MATRIX_END, start_idx)
-    new_matrix = render_matrix_include(versions)
-    text = text[:start_idx] + new_matrix + text[end_idx:]
-    CONTAINER_YML_PATH.write_text(text)
-    print(f"Updated matrix: {CONTAINER_YML_PATH}")
+def render_template(template_path: Path, output_path: Path, context: dict) -> None:
+    template_text = template_path.read_text()
+    template = jinja2.Template(template_text, keep_trailing_newline=True, trim_blocks=True, lstrip_blocks=True)
+    output = template.render(**context)
+    output_path.write_text(output)
+    print(f"Written: {output_path}")
 
 
 def main() -> None:
     versions = get_active_fedora_versions()
     if not versions:
-        print("ERROR: No active Fedora releases found from Bodhi API.", file=sys.stderr)
+        print("ERROR: No active Fedora releases found.", file=sys.stderr)
         sys.exit(1)
 
     print(f"Active Fedora releases: {versions}")
 
-    template_text = TEMPLATE_PATH.read_text()
-    template = jinja2.Template(template_text, keep_trailing_newline=True, trim_blocks=True, lstrip_blocks=True)
-    output = template.render(versions=versions)
-    BUILD_FMF_PATH.write_text(output)
-    print(f"Written: {BUILD_FMF_PATH}")
-
-    update_container_yml(versions)
+    context = {"versions": versions}
+    for template_path, output_path in TEMPLATES.items():
+        render_template(template_path, output_path, context)
 
 
 if __name__ == "__main__":

--- a/tmt/build.fmf
+++ b/tmt/build.fmf
@@ -1,0 +1,35 @@
+summary: Build and push nix-toolbox container images for all active Fedora releases.
+
+environment:
+  GIT_URL: https://github.com/thrix/nix-toolbox
+  GIT_REF: main
+  CONTAINER_FILE: Containerfile
+  BUILD_DIR: .
+
+discover:
+  how: fmf
+  url: https://gitlab.com/testing-farm/tests
+  test:
+    - /container/build
+
+provision:
+  how: container
+  image: quay.io/buildah/stable
+
+execute:
+  how: tmt
+
+/f42:
+  environment+:
+    BUILD_ARGS: "FEDORA_VERSION=42"
+    TARGET_IMAGE: ghcr.io/thrix/nix-toolbox:42
+
+/f43:
+  environment+:
+    BUILD_ARGS: "FEDORA_VERSION=43"
+    TARGET_IMAGE: ghcr.io/thrix/nix-toolbox:43
+
+/rawhide:
+  environment+:
+    BUILD_ARGS: "FEDORA_VERSION=rawhide"
+    TARGET_IMAGE: ghcr.io/thrix/nix-toolbox:rawhide

--- a/tmt/build.fmf
+++ b/tmt/build.fmf
@@ -21,15 +21,20 @@ execute:
 
 /f42:
   environment+:
-    BUILD_ARGS: "FEDORA_VERSION=42"
+    BUILD_ARGS: "--build-arg FEDORA_VERSION=42"
     TARGET_IMAGE: ghcr.io/thrix/nix-toolbox:42
 
 /f43:
   environment+:
-    BUILD_ARGS: "FEDORA_VERSION=43"
+    BUILD_ARGS: "--build-arg FEDORA_VERSION=43"
     TARGET_IMAGE: ghcr.io/thrix/nix-toolbox:43
+
+/f44:
+  environment+:
+    BUILD_ARGS: "--build-arg FEDORA_VERSION=44"
+    TARGET_IMAGE: ghcr.io/thrix/nix-toolbox:44
 
 /rawhide:
   environment+:
-    BUILD_ARGS: "FEDORA_VERSION=rawhide"
+    BUILD_ARGS: "--build-arg FEDORA_VERSION=rawhide"
     TARGET_IMAGE: ghcr.io/thrix/nix-toolbox:rawhide

--- a/tmt/build.fmf
+++ b/tmt/build.fmf
@@ -11,6 +11,9 @@ discover:
   url: https://gitlab.com/testing-farm/tests
   test:
     - /container/build
+  adjust-tests:
+    - duration: 1h
+      because: Accept the building time to be max 1 hour.
 
 provision:
   how: container

--- a/tmt/build.fmf.j2
+++ b/tmt/build.fmf.j2
@@ -1,0 +1,32 @@
+summary: Build and push nix-toolbox container images for all active Fedora releases.
+
+environment:
+  GIT_URL: https://github.com/thrix/nix-toolbox
+  GIT_REF: main
+  CONTAINER_FILE: Containerfile
+  BUILD_DIR: .
+
+discover:
+  how: fmf
+  url: https://gitlab.com/testing-farm/tests
+  test:
+    - /container/build
+
+provision:
+  how: container
+  image: quay.io/buildah/stable
+
+execute:
+  how: tmt
+{% for version in versions %}
+
+/f{{ version }}:
+  environment+:
+    BUILD_ARGS: "FEDORA_VERSION={{ version }}"
+    TARGET_IMAGE: ghcr.io/thrix/nix-toolbox:{{ version }}
+{% endfor %}
+
+/rawhide:
+  environment+:
+    BUILD_ARGS: "FEDORA_VERSION=rawhide"
+    TARGET_IMAGE: ghcr.io/thrix/nix-toolbox:rawhide

--- a/tmt/build.fmf.j2
+++ b/tmt/build.fmf.j2
@@ -11,6 +11,9 @@ discover:
   url: https://gitlab.com/testing-farm/tests
   test:
     - /container/build
+  adjust-tests:
+    - duration: 1h
+      because: Accept the building time to be max 1 hour.
 
 provision:
   how: container

--- a/tmt/build.fmf.j2
+++ b/tmt/build.fmf.j2
@@ -22,11 +22,11 @@ execute:
 
 /f{{ version }}:
   environment+:
-    BUILD_ARGS: "FEDORA_VERSION={{ version }}"
+    BUILD_ARGS: "--build-arg FEDORA_VERSION={{ version }}"
     TARGET_IMAGE: ghcr.io/thrix/nix-toolbox:{{ version }}
 {% endfor %}
 
 /rawhide:
   environment+:
-    BUILD_ARGS: "FEDORA_VERSION=rawhide"
+    BUILD_ARGS: "--build-arg FEDORA_VERSION=rawhide"
     TARGET_IMAGE: ghcr.io/thrix/nix-toolbox:rawhide

--- a/uv.lock
+++ b/uv.lock
@@ -273,14 +273,18 @@ name = "nix-toolbox"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "jinja2" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
+    { name = "requests" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "jinja2", specifier = ">=3.1" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", specifier = ">=9.6.14" },
+    { name = "requests", specifier = ">=2.32" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -97,6 +97,16 @@ wheels = [
 ]
 
 [[package]]
+name = "fedora-distro-aliases"
+version = "1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "munch" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/25/6270d969dbb89ad5c810ea1bb5119109d168899ba90314e5626673a9f989/fedora_distro_aliases-1.8.tar.gz", hash = "sha256:8e59bb968241dbdcf50ac909ead252cdda82e50a252f147aa391086b966b85fd", size = 7514, upload-time = "2025-10-25T11:56:38.447Z" }
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -269,22 +279,31 @@ wheels = [
 ]
 
 [[package]]
+name = "munch"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/2b/45098135b5f9f13221820d90f9e0516e11a2a0f55012c13b081d202b782a/munch-4.0.0.tar.gz", hash = "sha256:542cb151461263216a4e37c3fd9afc425feeaf38aaa3025cd2a981fadb422235", size = 19089, upload-time = "2023-07-01T09:49:35.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/b3/7c69b37f03260a061883bec0e7b05be7117c1b1c85f5212c72c8c2bc3c8c/munch-4.0.0-py2.py3-none-any.whl", hash = "sha256:71033c45db9fb677a0b7eb517a4ce70ae09258490e419b0e7f00d1e386ecb1b4", size = 9950, upload-time = "2023-07-01T09:49:34.472Z" },
+]
+
+[[package]]
 name = "nix-toolbox"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "fedora-distro-aliases" },
     { name = "jinja2" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
-    { name = "requests" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "fedora-distro-aliases", specifier = ">=1.0" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", specifier = ">=9.6.14" },
-    { name = "requests", specifier = ">=2.32" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Automated CI container builds via Testing Farm for all active Fedora releases (stable + branched) plus rawhide.

### New files

- **`scripts/generate-build-fmf.py`** — queries active Fedora releases via [`fedora-distro-aliases`](https://github.com/rpm-software-management/fedora-distro-aliases), renders `tmt/build.fmf` and `container.yml` from Jinja2 templates
- **`tmt/build.fmf.j2`** / **`tmt/build.fmf`** — tmt plan template and generated output; each Fedora version gets a separate plan section (`/tmt/build/f42`, `/tmt/build/f43`, etc.)
- **`.github/workflows/container.yml.j2`** / **`.github/workflows/container.yml`** — workflow template and generated output; matrix build (one Testing Farm request per version) triggered on push to `main`, PRs, weekly schedule, and manual dispatch; PR builds push to `pr-<number>-<version>` tags
- **`.github/workflows/refresh-build-fmf.yml`** — weekly regeneration of `tmt/build.fmf` and `container.yml` via `fedora-distro-aliases`, opens a PR if anything changed
- **`.gitattributes`** — marks generated files (`tmt/build.fmf`, `container.yml`) as `linguist-generated`

### Changed files

- **`Makefile`** — adds `generate/build-fmf` target; updates default `FEDORA_VERSION` from 42 to 43
- **`pyproject.toml`** / **`uv.lock`** — adds `jinja2` and `fedora-distro-aliases` dependencies
- **`.github/workflows/mkdocs.yml`** — removes unnecessary `issues: write` permission

### Prerequisites

Add the following secrets to the repository settings:

- `TESTING_FARM_API_TOKEN` — Testing Farm API token
- `GHCR_TOKEN` — classic GitHub PAT with `write:packages` scope (needed because the push happens on Testing Farm infrastructure where `GITHUB_TOKEN` is not valid)

Assisted-by: Claude Code