### PR TITLE
Fix fork bomb

### DIFF
--- a/nix.sh
+++ b/nix.sh
@@ -74,7 +74,7 @@ EOF
     echo
 
     gum log -l info "Installing nix in single-user mode"
-    gum spin -- bash -c "sh <(curl -sL https://nixos.org/nix/install) --no-daemon 2>&1"
+    gum spin -- bash --noprofile --norc -c "sh <(curl -sL https://nixos.org/nix/install) --no-daemon 2>&1"
 fi
 
 # Source nix environment


### PR DESCRIPTION
#41

## Summary by Sourcery

Bug Fixes:
- Run the Nix installer under a non-interactive bash invocation (disabling profile and rc files) to stop the script from re-invoking itself and creating a fork bomb.