### PR TITLE
Fix fork bomb

### DIFF
--- a/nix.sh
+++ b/nix.sh
@@ -74,7 +74,7 @@ EOF
     echo
 
     gum log -l info "Installing nix in single-user mode"
-    gum spin -- bash -c "sh <(curl -sL https://nixos.org/nix/install) --no-daemon 2>&1"
+    gum spin -- bash --noprofile --norc -c "sh <(curl -sL https://nixos.org/nix/install) --no-daemon 2>&1"
 fi
 
 # Source nix environment

--- a/nix.sh
+++ b/nix.sh
@@ -12,6 +12,12 @@ if ! command -v "gum" >/dev/null; then
     exit 1
 fi
 
+# Double source guard
+if [[ -n "$NIX_TOOLBOX_SOURCED" ]]; then
+    return 0
+fi
+export NIX_TOOLBOX_SOURCED=1
+
 # Nix does not like home being a symlink, use the real path instead
 HOME=$(readlink -f "$HOME")
 export HOME


### PR DESCRIPTION
fixes #41 

Confirmed it working by manually editing `/etc/profile.d/nix.sh` and reentering container.

<img width="1092" height="385" alt="изображение" src="https://github.com/user-attachments/assets/0257e6b4-3d9d-4825-85d6-82719b448888" />

## Summary by Sourcery

Prevent repeated sourcing of the nix toolbox shell script and harden the Nix installation invocation to avoid recursive shell initialization issues.

Bug Fixes:
- Guard nix.sh against being sourced multiple times in the same shell session.
- Run the Nix installer via bash without loading user profiles or rc files to prevent fork bomb behaviour.