### PR TITLE
Fix PR workflow perms

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -33,9 +33,6 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
 
-    permissions:
-      packages: write
-
     strategy:
       matrix:
         include:

--- a/.github/workflows/container.yml.j2
+++ b/.github/workflows/container.yml.j2
@@ -33,9 +33,6 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
 
-    permissions:
-      packages: write
-
     strategy:
       matrix:
         include:


### PR DESCRIPTION
The `container` workflow does not need permissions, we use a PAT to push to registry.

## Summary by Sourcery

CI:
- Update the container PR GitHub Actions workflow to request write access to packages for the build job.

## Summary by Sourcery

CI:
- Drop explicit packages: write permission from the container workflow and its Jinja template, relying instead on existing authentication.