### PR TITLE
Adjust markdownlint to use correct rule name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,9 +42,9 @@ repos:
           - .markdownlint.yaml
           - --fix
           - --rules
-          - sentences-per-line
+          - markdownlint-sentences-per-line
         additional_dependencies:
-          - sentences-per-line
+          - markdownlint-sentences-per-line
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.2


### PR DESCRIPTION
This recently changed and broke the check.

## Summary by Sourcery

Build:
- Switch markdownlint hook arguments and dependency from sentences-per-line to markdownlint-sentences-per-line to align with upstream changes.